### PR TITLE
Secure UI data fetches and async helpers

### DIFF
--- a/scripts/emsctl
+++ b/scripts/emsctl
@@ -2,9 +2,9 @@
 """Operational CLI for the EMS edge agent."""
 from __future__ import annotations
 
-import asyncio
 import json
 import os
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -49,7 +49,7 @@ def tail(log_file: Path = Path("/var/log/ems/ems.jsonl")) -> None:
             while True:
                 line = fh.readline()
                 if not line:
-                    asyncio.sleep(0.5)
+                    time.sleep(0.5)
                     continue
                 typer.echo(line.strip())
         except KeyboardInterrupt:

--- a/scripts/modbus_scan.py
+++ b/scripts/modbus_scan.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import csv
 import random
-import time
 from typing import Iterable
 
 from pymodbus.client import AsyncModbusTcpClient
@@ -22,7 +22,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--end", type=int, default=100, help="End register")
     parser.add_argument("--fc", choices=[3, 4], type=int, default=3, help="Function code")
     parser.add_argument("--count", type=int, default=1, help="Registers per request")
-    parser.add_argument("--delay", type=float, default=SAFE_DELAY, help="Delay between requests (s)")
+    parser.add_argument(
+        "--delay", type=float, default=SAFE_DELAY, help="Delay between requests (s)"
+    )
     parser.add_argument("--output", default="scan.csv", help="CSV output path")
     return parser.parse_args()
 
@@ -46,13 +48,15 @@ async def main() -> None:
     try:
         for group in chunked(range(args.start, args.end + 1), args.count):
             address = group[0]
-            resp = await client.read_holding_registers(address=address, count=len(group), unit=args.unit)
+            resp = await client.read_holding_registers(
+                address=address, count=len(group), unit=args.unit
+            )
             if resp.isError():
                 value = None
             else:
                 value = list(resp.registers)
             results.append({"address": address, "value": value})
-            time.sleep(args.delay + random.uniform(0, 0.1))
+            await asyncio.sleep(args.delay + random.uniform(0, 0.1))
     finally:
         await client.close()
     with open(args.output, "w", newline="", encoding="utf-8") as fh:
@@ -64,6 +68,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    import asyncio
-
     asyncio.run(main())

--- a/src/ems/store/exporter.py
+++ b/src/ems/store/exporter.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import asyncio
 import pandas as pd
 
-from .database import Database
+from .database import Database, MeasurementRecord
 
 
 class ParquetExporter:
@@ -19,6 +20,11 @@ class ParquetExporter:
         records = await self._db.latest_measurements(since=cutoff)
         if not records:
             return None
+        return await asyncio.to_thread(self._write_parquet, records, cutoff)
+
+    def _write_parquet(
+        self, records: list[MeasurementRecord], cutoff: datetime
+    ) -> Path:  # pragma: no cover - exercised via export_last_hour
         df = pd.DataFrame(
             [
                 {


### PR DESCRIPTION
## Summary
- protect UI JSON helpers with basic auth, respect the ui.enabled flag, and expose a safe /ui/api/devices endpoint
- update the frontend bundle to drop the baked-in bearer token and fix the fleet chart data source
- correct blocking sleeps, offload parquet exports to a worker thread, and skip empty uplink payloads while extending API tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d12e4df83c832cb5fe184195d92a1e